### PR TITLE
Document matplotlib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "dash",
   "nbformat",
   "scipy",
+  "matplotlib"
 ]
 
 authors = [


### PR DESCRIPTION
Added in 2e9bde46883837e2601e1e4bb5be2dc1991d1508.

This should fix the CI failures seen in #7. Once this pull request is merged, you can rebase #7 or merge `main` into it and the tests should now hopefully pass.